### PR TITLE
fixed keywords for Meyer 2024 Sparql Benchmarking

### DIFF
--- a/aksw.bib
+++ b/aksw.bib
@@ -12550,7 +12550,7 @@ Results: https://github.com/AKSW/AI-Tomorrow-2023-KG-ChatGPT-Experiments},
   abstract = {The integration of Large Language Models (LLMs) with Knowledge Graphs (KGs) offers significant synergistic potential for knowledge-driven applications. One possible integration is the interpretation and generation of formal languages, such as those used in the Semantic Web, with SPARQL being a core technology for accessing KGs. In this paper, we focus on measuring out-of-the box capabilities of LLMs to work with SPARQL and more specifically with SPARQL SELECT queries applying a quantitative approach. We implemented various benchmarking tasks in the LLM-KG-Bench framework for automated execution and evaluation with several LLMs. The tasks assess capabilities along the dimensions of syntax, semantic read, semantic create, and the role of knowledge graph prompt inclusion. With this new benchmarking tasks, we evaluated a selection of GPT, Gemini, and Claude models. Our findings indicate that working with SPARQL SELECT queries is still challenging for LLMs and heavily depends on the specific LLM as well as the complexity of the task. While fixing basic syntax errors seems to pose no problems for the best of the current LLMs evaluated, creating semantically correct SPARQL SELECT queries is difficult in several cases.},
   comment  = {to appear in Proceedings of Workshop NLP4KGC @SEMANTICS 2024},
   doi      = {10.48550/ARXIV.2409.05925},
-  keywords = {group_aksw,sys:relevantFor:infai,es,lpmeyer,brei,frey,arndt},
+  keywords = {group_aksw sys:relevantFor:infai es lpmeyer brei frey arndt},
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
keywords need to be separated by space, not comma